### PR TITLE
Added Legend Of Intensity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,48 @@ package is available through [npm](https://www.npmjs.com/package/epiviz.heatmap.
 
 - [app/index.html](./app/index.html) provides an easier example and code on how to use the library
 
+#### Intensity Legend
+
+Adding an Intensity Legend is optional. If you wish to add one, the simplest way is to provide the data in the following format:
+
+```javascript
+[
+  { color: "#fff", intensity: 0.1, label: "-2" },
+  { color: "#fff", intensity: 0.2, label: "-1.5" },
+];
+```
+
+You can use the existing setState method to provide the legend Data encoding like so:
+
+```javascript
+plot.setState({
+  legendIntensityData,
+});
+```
+
+With this option, the intensity legend will render at the bottom of the graph by default. You can always change the position using the setIntensityLegendOptions method:
+
+```javascript
+setIntensityLegendOptions("top" | "bottom" | "left" | "right");
+```
+
+If you wish for the legend to be rendered somewhere else in the DOM, you must provide the selector or DOM element, along with the position/type of intensity legend you want, for example:
+
+```javascript
+setIntensityLegendOptions("top", ".intensity-legend");
+```
+
+You can also specify width and height:
+
+```javascript
+setIntensityLegendOptions("top", ".intensity-legend", 400, 500);
+```
+
 #### React Usage
 
 To use the library in a React application
 
-```
+```javascript
 import { ReactDotplot } from 'epiviz.heatmap.gl/react'
 
 const Component = () => {
@@ -107,6 +144,7 @@ plot.setInteraction("pan");
 - hoverCallback
 - clickCallback
 - selectionCallback
+- highlightedIndicesCallback
 
 **_hover and click also provide the distance of the point from the mouse location. This metric can be used to enable various interactions._**
 
@@ -124,6 +162,11 @@ plot.selectionCallback = function (points) {
   // ... do something ...
   console.log(points);
 };
+
+plot.highlightedIndicesCallback = function (indices) {
+  // ... do something ...
+  console.log(indices);
+};
 ```
 
 #### Encodings
@@ -134,6 +177,8 @@ These attributes either take a fixed value or an array of values for each data p
 - `size` - size of each dot
 - `opacity` - opacity across the entire plot
 - `xgap` or `ygap` - gap between rows and columns
+- `intensityLegendData` - an array of objects containing color, intensity, and label for the legend.
+  e.g [{color: "#000000", intensity: 1, label: "0.1"}]
 
 ```js
   plot.setState({
@@ -142,5 +187,6 @@ These attributes either take a fixed value or an array of values for each data p
     xgap: <GAPS>,
     ygap: <GAPS>,
     opacity: <OPACITY>
+    intensityLegendData: <INTENSITY_LEGEND_DATA>
   });
 ```

--- a/app/data.js
+++ b/app/data.js
@@ -23,7 +23,19 @@ for (let ily = 0; ily < ncols; ily++) {
 }
 
 // map intensities to color
-let color_map = var_intensity.map((x, i) => d3.interpolateViridis(x))
+let color_map = var_intensity.map((x, i) => d3.interpolateViridis(x));
+
+let intensityLegendData = [];
+
+for (let i = 0; i < 1; i += 0.1) {
+  const intensity = Math.round(i * 100) / 100;
+
+  intensityLegendData.push({
+    color: d3.interpolateViridis(i),
+    intensity,
+    label: intensity,
+  });
+}
 
 const data = {
   x: x,
@@ -35,4 +47,4 @@ const data = {
 const color = color_map;
 const size = var_size;
 
-export { data, color, size };
+export { data, color, size, intensityLegendData };

--- a/app/ehgl.js
+++ b/app/ehgl.js
@@ -24,76 +24,27 @@ const getMinMax = (arr) => {
   return [min, max];
 };
 
-/**
- * Function to convert a hexadecimal color to its RGB equivalent.
- *
- * @param {string} hex - The hexadecimal color string. Must start with "#" and be followed by 6 hexadecimal digits.
- * @returns {Array<number>} An array containing the RGB values (0-255) in the order [r, g, b].
- */
-function hexToRGB(hex) {
-  let r = parseInt(hex.slice(1, 3), 16),
-    g = parseInt(hex.slice(3, 5), 16),
-    b = parseInt(hex.slice(5, 7), 16);
-  return [r, g, b];
-}
+const parseMargins = (margins) => {
+  const parsedMargins = {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  };
 
-/**
- * Function to convert an RGB color to its hexadecimal equivalent.
- *
- * @param {Array<number>} rgb - An array of three numbers [r, g, b] representing an RGB color.
- * @returns {string} A string representing the color in hexadecimal format.
- */
-function rgbToHex(rgb) {
-  let r = rgb[0].toString(16),
-    g = rgb[1].toString(16),
-    b = rgb[2].toString(16);
-  return (
-    "#" +
-    ((r.length == 1 ? "0" : "") + r) +
-    ((g.length == 1 ? "0" : "") + g) +
-    ((b.length == 1 ? "0" : "") + b)
-  );
-}
+  for (let key in margins) {
+    if (margins.hasOwnProperty(key)) {
+      const value = margins[key];
+      const parsedValue = parseInt(value, 10);
 
-/**
- * Function to mix a color with white to create a "brightened" effect.
- *
- * @param {Array<number>} rgb - An array of three numbers [r, g, b] representing an RGB color.
- * @param {number} amount - The brightening factor. A value between 0 (no change) and 1 (complete white).
- * @returns {Array<number>} An array containing the RGB values of the brightened color.
- */
-function mixWithWhite(rgb, amount) {
-  return [
-    Math.floor(rgb[0] + (255 - rgb[0]) * amount),
-    Math.floor(rgb[1] + (255 - rgb[1]) * amount),
-    Math.floor(rgb[2] + (255 - rgb[2]) * amount),
-  ];
-}
-
-/**
- * Function to convert a color from the "rgb(r, g, b)" string format to an array of numbers.
- *
- * @param {string} rgbStr - The color in "rgb(r, g, b)" string format.
- * @returns {Array<number>} An array containing the RGB values (0-255) in the order [r, g, b].
- */
-function strToRGB(rgbStr) {
-  let match = rgbStr.match(/rgb\((\d+), (\d+), (\d+)\)/);
-  if (match) {
-    return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])];
-  } else {
-    throw new Error("Invalid RGB string format");
+      if (!isNaN(parsedValue)) {
+        parsedMargins[key] = parsedValue;
+      }
+    }
   }
-}
 
-/**
- * Function to determine whether a given color is in RGB format.
- *
- * @param {Array<number> | string} color - The color in either RGB format (as a string in the "rgb(r, g, b)" format) or hexadecimal format (as a string).
- * @returns {boolean} True if the color is in RGB format, false otherwise.
- */
-function isRGB(color) {
-  return color.startsWith("rgb");
-}
+  return parsedMargins;
+};
 
 /**
  * Base class for all matrix like layout plots.
@@ -112,6 +63,8 @@ class BaseGL {
    */
   constructor(selectorOrElement) {
     this.elem = selectorOrElement;
+    // Default legend position
+    this.legendPosition = "bottom";
     if (
       typeof selectorOrElement === "string" ||
       selectorOrElement instanceof String
@@ -156,13 +109,14 @@ class BaseGL {
         sdata &&
         sdata.selection.indices.length > 0
       ) {
-        this.highlightIndices(sdata.selection.indices, true);
+        this.highlightIndices(sdata.selection.indices, null, true);
       }
 
       self.selectionCallback(e.detail.data);
     });
 
     this.highlightedIndices = [];
+    this.indexStates = {};
   }
 
   /**
@@ -230,9 +184,13 @@ class BaseGL {
    * @param {Array} data.y, y coordinates
    * @param {Array} data.xlabels, labels along the x-axis
    * @param {Array} data.ylabels, labels along the y-axis
+   * @param {Array} legendData, data for the legend
+   * @param {Array} legendData.labels, labels for the legend
+   * @param {Array} legendData.colors, colors for the legend
+   * @param {Array} legendData.intensity, intensity for the color inside legend
    * @memberof BaseGL
    */
-  setInput(data) {
+  setInput(data, legendData = null) {
     if (
       isObject(data) &&
       "x" in data &&
@@ -294,6 +252,8 @@ class BaseGL {
     } else {
       throw `input data must contain x and y attributes`;
     }
+
+    this.legendData = legendData;
   }
 
   /**
@@ -356,6 +316,22 @@ class BaseGL {
   }
 
   /**
+   * Set the legend options for the visualization.
+   * @param {string} legentPosition, position of the legend, can be `top`, `bottom`, `left` or `right`
+   * @param {DOMElement} legendDomElement, the DOM element to use for the legend
+   **/
+  setIntensityLegendOptions(legentPosition, legendDomElement, width, height) {
+    this.isLegendDomElementProvided = !!legendDomElement;
+    this.legendPosition = legentPosition;
+    this.legendWidth = width;
+    this.legendHeight = height;
+
+    if (!legendDomElement) {
+      this.legendDomElement = this.elem.lastChild;
+    } else this.legendDomElement = legendDomElement;
+  }
+
+  /**
    * resize the plot, without having to send the data to the GPU.
    *
    * @param {number} width
@@ -412,6 +388,10 @@ class BaseGL {
     if (height) {
       this._spec.height = height;
     }
+    // Render the legend
+    if (this.legendData && this.legendDomElement) {
+      this.renderLegend();
+    }
 
     if (this._renderCount == 0) {
       this.plot.setSpecification(this._spec);
@@ -444,32 +424,224 @@ class BaseGL {
       }
 
       if (this.highlightEnabled && hdata && hdata.indices.length > 0) {
-        this.highlightIndices(hdata.indices);
+        const index = hdata.indices[0];
+        const shouldHighlight = !this.indexStates[index]; // reverse the current state
+        this.indexStates[index] = shouldHighlight;
+        this.highlightIndices([index], shouldHighlight);
       }
 
       self.clickCallback(hdata);
     });
+
+    this.plot.addEventListener("labelClicked", (e) => {
+      e.preventDefault();
+      if (this.highlightEnabled && e && e.detail && e.detail.labelObject) {
+        const type = e.detail.labelObject.type;
+        const index = e.detail.labelObject.index;
+        const indices = [];
+        if (type === "column") {
+          for (let i = index; i < this.ncols * this.nrows; i += this.nrows) {
+            indices.push(i);
+          }
+        } else if (type === "row") {
+          for (let i = index * this.nrows; i < (index + 1) * this.nrows; i++) {
+            indices.push(i);
+          }
+        }
+
+        // Decide whether to highlight or unhighlight
+        const shouldHighlight = indices.some(
+          (index) => !this.indexStates[index]
+        );
+        indices.forEach((index) => (this.indexStates[index] = shouldHighlight));
+
+        this.highlightIndices(indices, shouldHighlight);
+      }
+    });
   }
 
-  highlightIndices(indices, forceSet = false) {
+  /**
+   * Render the legend for the intensity plot.
+   * This is used to render the legend for the intensity plot.
+   **/
+  renderLegend() {
+    const position = this.legendPosition;
+    // Only render the legend if we have the legend data and the legend dom element
+    if (!this.legendDomElement || !this.legendData) return;
+
+    const parsedMargins = parseMargins(this._spec.margins);
+    const containerWidth =
+      this.legendWidth ||
+      this.elem.clientWidth - parsedMargins.left - parsedMargins.right;
+    const containerHeight =
+      this.legendHeight ||
+      this.elem.clientHeight - parsedMargins.top - parsedMargins.bottom;
+
+    const averageCharWidth = 6; // rough estimation of the width of a single character
+    const legendWidth = containerWidth - 2 * averageCharWidth;
+    const legendHeight = containerHeight - 2 * averageCharWidth;
+    const legendSize = 20;
+    const labelSize = 25;
+
+    // Adjust the SVG size and the legend position according to the position parameter
+    let svgWidth, svgHeight, transformX, transformY;
+    if (position === "left" || position === "right") {
+      svgWidth = legendSize + labelSize;
+      svgHeight = containerHeight;
+      transformY = averageCharWidth;
+    } else {
+      svgWidth = containerWidth;
+      svgHeight = legendSize + labelSize;
+      transformX = averageCharWidth;
+    }
+
+    const svgContainer = d3
+      .select(this.legendDomElement)
+      .append("svg")
+      .attr("width", svgWidth)
+      .attr("height", svgHeight)
+      .attr("overflow", "visible");
+
+    const defs = svgContainer.append("defs");
+
+    const gradientId = `linear-gradient-${(Math.random() * 1000).toFixed()}`;
+
+    const gradient = defs
+      .append("linearGradient")
+      .attr("id", gradientId)
+      .attr("x1", "0%")
+      .attr("y1", "0%")
+      .attr("x2", position === "left" || position === "right" ? "0%" : "100%")
+      .attr("y2", position === "left" || position === "right" ? "100%" : "0%");
+
+    gradient
+      .selectAll("stop")
+      .data(this.legendData)
+      .enter()
+      .append("stop")
+      .attr("offset", (d) => d.intensity * 100 + "%")
+      .attr("stop-color", (d) => d.color);
+
+    // Create a mapping from intensity to label
+    const intensityToLabel = {};
+    this.legendData.forEach((d) => {
+      if (d.label !== "") {
+        intensityToLabel[d.intensity] = d.label;
+      }
+    });
+
+    const intensityScale = d3
+      .scaleLinear()
+      .range([
+        0,
+        position === "left" || position === "right"
+          ? legendHeight
+          : legendWidth,
+      ])
+      .domain([0, 1]);
+
+    let legendAxis;
+    if (position === "left") {
+      legendAxis = d3.axisLeft(intensityScale);
+      transformX = labelSize;
+    } else if (position === "top") {
+      legendAxis = d3.axisTop(intensityScale);
+      transformY = labelSize;
+    } else if (position === "right") {
+      transformX = legendSize;
+      legendAxis = d3.axisRight(intensityScale);
+    } else {
+      transformY = legendSize;
+      legendAxis = d3.axisBottom(intensityScale);
+    }
+
+    legendAxis
+      .tickValues(Object.keys(intensityToLabel).map(Number)) // Only use intensities that have labels
+      .tickFormat((d) => intensityToLabel[d]); // Use the intensity to label mapping
+
+    svgContainer
+      .append("g")
+      .attr("transform", `translate(${transformX}, ${transformY})`)
+      .call(legendAxis);
+
+    const maxLabelChars = Math.max(
+      ...this.legendData.map((d) => d.label.toString().length)
+    ); // length of the longest label
+
+    let rectX, rectY;
+    if (position === "top") {
+      rectX = averageCharWidth;
+      rectY = maxLabelChars * averageCharWidth + 8; // Offset to move gradient down
+    } else if (position === "left") {
+      rectX = maxLabelChars * averageCharWidth + 8; // Offset to move gradient right
+      rectY = averageCharWidth;
+    } else if (position === "right") {
+      rectY = averageCharWidth;
+      rectX = 0;
+    } else if (position === "bottom") {
+      rectX = averageCharWidth;
+      rectY = 0;
+    }
+
+    svgContainer
+      .append("rect")
+      .attr(
+        "width",
+        position === "left" || position === "right" ? legendSize : legendWidth
+      )
+      .attr(
+        "height",
+        position === "left" || position === "right" ? legendHeight : legendSize
+      )
+      .style("fill", `url(#${gradientId})`)
+      .attr("x", rectX)
+      .attr("y", rectY);
+
+    // Update margins to account for the legend only if dom element is not provided
+    if (!this.isLegendDomElementProvided) {
+      this._spec.margins = {
+        ...this._spec.margins,
+        [position]: `calc(${
+          (position === "left" || position === "right" ? 45 : 45) + "px"
+        } + ${this._spec.margins[position]})`,
+      };
+
+      // set svg container to position absolute and position value to 0
+      svgContainer.style("position", "absolute").style(position, "0px");
+
+      if (position === "right" || position === "left") {
+        svgContainer.style("margin-top", parsedMargins.top);
+      } else if (position === "top" || position === "bottom") {
+        svgContainer.style("margin-left", parsedMargins.left);
+      }
+    }
+  }
+
+  /**
+   * Highlight the indices on the plot.
+   * @memberof BaseGL
+   * @param {Array} indices, indices to be highlighted.
+   * @param {boolean} forceSet, if true, set the indices to be highlighted, else toggle the indices.
+   * @example
+   * // Highlight indices
+   * plot.highlightIndices([1, 2, 3]);
+   **/
+  highlightIndices(indices, shouldHighlight, forceSet = false) {
     if (forceSet) {
       this.highlightedIndices = [...indices];
-    } else if (this.highlightedIndices.length > 0) {
+      indices.forEach((index) => (this.indexStates[index] = true));
+    } else {
       indices.forEach((index) => {
         const foundIndex = this.highlightedIndices.indexOf(index);
-        if (foundIndex > -1) {
-          this.highlightedIndices = this.highlightedIndices.filter(
-            (item) => item !== index
-          );
-        } else {
+        if (!shouldHighlight && foundIndex > -1) {
+          this.highlightedIndices.splice(foundIndex, 1);
+        } else if (shouldHighlight && foundIndex === -1) {
           this.highlightedIndices.push(index);
         }
       });
-    } else {
-      this.highlightedIndices.push(...indices);
     }
     this.highlightedIndicesCallback(this.highlightedIndices);
-    this.reRender();
+    this.reRenderOnHighlight();
   }
 
   /**
@@ -506,33 +678,38 @@ class BaseGL {
    **/
   clearHighlight() {
     this.highlightedIndices = [];
+    this.indexStates = {};
     this.highlightedIndicesCallback(this.highlightedIndices);
-    this.reRender();
+    this.reRenderOnHighlight();
   }
 
   /**
-   * Re-render the plot. This is useful when the data is updated.
+   * Re-render the plot. This is useful when the highlight data is updated.
    * @memberof BaseGL
    */
-  reRender() {
-    this.plot.updateSpecification({
-      ...this._spec,
-      defaultData: {
-        ...this._spec.defaultData,
-        color: this._spec.defaultData.color.map((color, index) => {
-          if (
-            this.highlightedIndices.length === 0 ||
-            this.highlightedIndices.includes(index)
-          ) {
-            return color;
-          } else {
-            const rgb = isRGB(color) ? strToRGB(color) : hexToRGB(color);
-            const dimmedRgb = mixWithWhite(rgb, 0.7); // 0.7 is the dimming factor
-            return rgbToHex(dimmedRgb);
-          }
-        }),
-      },
-    });
+  reRenderOnHighlight() {
+    const opacityData = this.createOpacityArray(
+      this._spec.defaultData.color.length,
+      this.highlightedIndices
+    );
+    this._generateSpecForEncoding(this._spec, "opacity", opacityData);
+    this.plot.updateSpecification(this._spec);
+  }
+
+  /**
+   * Create an array of length `length` with the specified indexes set to 1
+   * @memberof BaseGL
+   * @param {number} length, length of the array
+   * @param {Array} indexes, indexes to be set to 1
+   * @return {Array} an array of length `length` with the specified indexes set to 1
+   **/
+  createOpacityArray(length, indexes) {
+    // Create an array of length `length` with all values set to 0.4 if indexes are specified else 1
+    const arr = new Array(length).fill(indexes.length ? 0.4 : 1);
+    for (let i of indexes) {
+      arr[i] = 1; // Set the specified indexes to 1
+    }
+    return arr;
   }
 
   /**
@@ -545,7 +722,7 @@ class BaseGL {
    */
   clearHighlightedIndices() {
     this.highlightedIndices = [];
-    this.reRender();
+    this.reRenderOnHighlight();
   }
 
   /**
@@ -639,6 +816,8 @@ class DotplotGL extends BaseGL {
         labels.push({
           x: -1.05 + (2 * ilx + 1) / xlabels_len,
           y: 1.05,
+          type: "row",
+          index: ilx,
           text: this.input["xlabels"][ilx],
           fixedY: true,
           "text-anchor": "center",
@@ -656,6 +835,8 @@ class DotplotGL extends BaseGL {
         labels.push({
           x: -1.05,
           y: -1.05 + (2 * ily + 1) / ylabels_len,
+          type: "column",
+          index: ily,
           text: this.input["ylabels"][ily],
           fixedX: true,
           "text-anchor": "end",
@@ -723,7 +904,6 @@ class DotplotGL extends BaseGL {
  * @extends {BaseGL}
  */
 class RectplotGL extends BaseGL {
-
   /**
    * Creates an instance of RectplotGL.
    * @param {string} selectorOrElement, a html dom selector or element.
@@ -746,7 +926,7 @@ class RectplotGL extends BaseGL {
    * Generate the specification for Rect heatmap Plots.
    * checkout epiviz.gl for more information.
    *
-   * @return {object} a specification object that epiviz.gl can understand 
+   * @return {object} a specification object that epiviz.gl can understand
    * @memberof RectplotGL
    */
   generateSpec() {
@@ -788,6 +968,8 @@ class RectplotGL extends BaseGL {
         labels.push({
           x: -1.05 + (2 * ilx + 1) / xlabels_len,
           y: 1.05,
+          type: "row",
+          index: ilx,
           text: this.input["xlabels"][ilx],
           fixedY: true,
           "text-anchor": "center",
@@ -805,6 +987,8 @@ class RectplotGL extends BaseGL {
         labels.push({
           x: -1.05,
           y: -1.05 + (2 * ily + 1) / ylabels_len,
+          type: "column",
+          index: ily,
           text: this.input["ylabels"][ily],
           fixedX: true,
           "text-anchor": "end",
@@ -869,8 +1053,6 @@ class RectplotGL extends BaseGL {
  * @extends {BaseGL}
  */
 class TickplotGL extends BaseGL {
-
-
   /**
    * Creates an instance of TickplotGL.
    * @param {string} selectorOrElement, a html dom selector or element.
@@ -889,12 +1071,11 @@ class TickplotGL extends BaseGL {
     };
   }
 
-
   /**
    * Generate the specification for Tick Plots.
    * checkout epiviz.gl for more information.
    *
-   * @return {object} a specification object that epiviz.gl can understand 
+   * @return {object} a specification object that epiviz.gl can understand
    * @memberof TickplotGL
    */
   generateSpec() {
@@ -911,6 +1092,8 @@ class TickplotGL extends BaseGL {
         labels.push({
           x: -1 + (2 * ilx + 1) / xlabels_len,
           y: 1.05,
+          type: "row",
+          index: ilx,
           text: this.input["xlabels"][ilx],
           fixedY: true,
           "text-anchor": "center",
@@ -928,6 +1111,8 @@ class TickplotGL extends BaseGL {
         labels.push({
           x: -1.1,
           y: -1 + (2 * ily + 1) / ylabels_len,
+          type: "column",
+          index: ily,
           text: this.input["ylabels"][ily],
           fixedX: true,
           "text-anchor": "end",

--- a/app/ehgl.js
+++ b/app/ehgl.js
@@ -184,13 +184,9 @@ class BaseGL {
    * @param {Array} data.y, y coordinates
    * @param {Array} data.xlabels, labels along the x-axis
    * @param {Array} data.ylabels, labels along the y-axis
-   * @param {Array} legendData, data for the legend
-   * @param {Array} legendData.labels, labels for the legend
-   * @param {Array} legendData.colors, colors for the legend
-   * @param {Array} legendData.intensity, intensity for the color inside legend
    * @memberof BaseGL
    */
-  setInput(data, legendData = null) {
+  setInput(data) {
     if (
       isObject(data) &&
       "x" in data &&
@@ -252,8 +248,6 @@ class BaseGL {
     } else {
       throw `input data must contain x and y attributes`;
     }
-
-    this.legendData = legendData;
   }
 
   /**
@@ -265,6 +259,8 @@ class BaseGL {
    * @param {Array|number} encoding.opacity, same as size, but sets the opacity for each cell.
    * @param {Array|number} encoding.xgap, same as size, but sets the gap along x-axis.
    * @param {Array|number} encoding.ygap, same as size, but sets the gap along y-axis.
+   * @param {Array} encoding.legendIntensityData, an array of objects containing color, intensity, and label for the legend.
+   * e.g  [{color: "#000000", intensity: 1, label: "0.1"}]
    * @memberof BaseGL
    */
   setState(encoding) {
@@ -294,6 +290,10 @@ class BaseGL {
 
     if ("ygap" in encoding) {
       this.state["ygap"] = encoding["ygap"];
+    }
+
+    if ("intensityLegendData" in encoding) {
+      this.intensityLegendData = encoding["intensityLegendData"];
     }
   }
 
@@ -389,7 +389,7 @@ class BaseGL {
       this._spec.height = height;
     }
     // Render the legend
-    if (this.legendData && this.legendDomElement) {
+    if (this.intensityLegendData && this.legendDomElement) {
       this.renderLegend();
     }
 
@@ -467,7 +467,7 @@ class BaseGL {
   renderLegend() {
     const position = this.legendPosition;
     // Only render the legend if we have the legend data and the legend dom element
-    if (!this.legendDomElement || !this.legendData) return;
+    if (!this.legendDomElement || !this.intensityLegendData) return;
 
     const parsedMargins = parseMargins(this._spec.margins);
     const containerWidth =
@@ -516,7 +516,7 @@ class BaseGL {
 
     gradient
       .selectAll("stop")
-      .data(this.legendData)
+      .data(this.intensityLegendData)
       .enter()
       .append("stop")
       .attr("offset", (d) => d.intensity * 100 + "%")
@@ -524,7 +524,7 @@ class BaseGL {
 
     // Create a mapping from intensity to label
     const intensityToLabel = {};
-    this.legendData.forEach((d) => {
+    this.intensityLegendData.forEach((d) => {
       if (d.label !== "") {
         intensityToLabel[d.intensity] = d.label;
       }
@@ -565,7 +565,7 @@ class BaseGL {
       .call(legendAxis);
 
     const maxLabelChars = Math.max(
-      ...this.legendData.map((d) => d.label.toString().length)
+      ...this.intensityLegendData.map((d) => d.label.toString().length)
     ); // length of the longest label
 
     let rectX, rectY;

--- a/app/index.html
+++ b/app/index.html
@@ -249,7 +249,7 @@
 
     let plot = new DotplotGL(".dotcanvas");
     plot.setInput(data, intensityLegendData);
-    plot.setIntensityLegendOptions("bottom", ".dotcanvas-intensity");
+    plot.setIntensityLegendOptions("bottom", ".dotcanvas-intensity", 400, 500);
 
     plot.hoverCallback = function (point) {
       if (point) {

--- a/app/index.html
+++ b/app/index.html
@@ -248,7 +248,7 @@
     import { data, color, size, intensityLegendData } from './data.js';
 
     let plot = new DotplotGL(".dotcanvas");
-    plot.setInput(data, intensityLegendData);
+    plot.setInput(data);
     plot.setIntensityLegendOptions("bottom", ".dotcanvas-intensity", 400);
 
     plot.hoverCallback = function (point) {
@@ -284,6 +284,7 @@
     plot.setState({
       "size": size,
       "color": color,
+      intensityLegendData,
     });
 
     plot.render();
@@ -341,6 +342,7 @@
     plot2.setState({
       "size": size,
       "color": color,
+      intensityLegendData,
     });
 
     plot2.render();

--- a/app/index.html
+++ b/app/index.html
@@ -249,7 +249,7 @@
 
     let plot = new DotplotGL(".dotcanvas");
     plot.setInput(data, intensityLegendData);
-    plot.setIntensityLegendOptions("bottom", ".dotcanvas-intensity", 400, 500);
+    plot.setIntensityLegendOptions("bottom", ".dotcanvas-intensity", 400);
 
     plot.hoverCallback = function (point) {
       if (point) {

--- a/app/index.html
+++ b/app/index.html
@@ -36,11 +36,29 @@
       height: 400px;
       width: 400px;
       border: 1px solid black;
-      margin: 40px;
+      margin: 40px 40px 0 40px;
+    }
+
+    .dotcanvas-controls {
+      grid-row: 2;
+      grid-column: 2;
+      margin: 0px 40px;
+    }
+
+    .dotcanvas-intensity {
+      grid-row: 3;
+      grid-column: 2;
+      margin: 0px 40px;
+    }
+
+    .rectcanvas-controls {
+      grid-row: 4;
+      grid-column: 2;
+      margin: 0px 40px;
     }
 
     .rectcanvas {
-      grid-row: 3;
+      grid-row: 4;
       grid-column: 2;
       height: 400px;
       width: 400px;
@@ -57,8 +75,15 @@
       margin: 40px;
     }
 
+
+    .tickcanvas-controls {
+      grid-row: 5;
+      grid-column: 2;
+      margin: 0px 40px;
+    }
+
     .tickcanvas {
-      grid-row: 6;
+      grid-row: 5;
       grid-column: 2;
       height: 400px;
       width: 400px;
@@ -175,6 +200,8 @@
       <h4>Github Commit graph</h4>
       <p>someone is a profilic programmer
         <div class="ghcanvas">
+        </div>
+        <div class="ghcanvas-controls">
           <button class="canvas-pan">pan</button>
           <button class="canvas-box">box</button>
           <button class="canvas-lasso">lasso</button>
@@ -185,6 +212,8 @@
       </p>
     </div>
     <div class="dotcanvas">
+    </div>
+    <div class="dotcanvas-controls">
       <button class="canvas-pan">pan</button>
       <button class="canvas-box">box</button>
       <button class="canvas-lasso">lasso</button>
@@ -192,7 +221,10 @@
       <button class="disable-highlight">disable highlight</button>
       <button class="clear-highlight">clear highlight</button>
     </div>
+    <div class="dotcanvas-intensity"></div>
     <div class="rectcanvas">
+    </div>
+    <div class="rectcanvas-controls">
       <button class="canvas-pan">pan</button>
       <button class="canvas-box">box</button>
       <button class="canvas-lasso">lasso</button>
@@ -201,6 +233,8 @@
       <button class="clear-highlight">clear highlight</button>
     </div>
     <div class="tickcanvas">
+    </div>
+    <div class="tickcanvas-controls">
       <button class="canvas-pan">pan</button>
       <button class="canvas-box">box</button>
       <button class="canvas-lasso">lasso</button>
@@ -211,10 +245,11 @@
   </div>
   <script type="module">
     import { DotplotGL, RectplotGL, TickplotGL } from "./index.js";
-    import { data, color, size } from './data.js';
+    import { data, color, size, intensityLegendData } from './data.js';
 
     let plot = new DotplotGL(".dotcanvas");
-    plot.setInput(data);
+    plot.setInput(data, intensityLegendData);
+    plot.setIntensityLegendOptions("bottom", ".dotcanvas-intensity");
 
     plot.hoverCallback = function (point) {
       if (point) {
@@ -253,33 +288,35 @@
 
     plot.render();
 
-    document.querySelector(".dotcanvas>.canvas-box").addEventListener("click", () => {
+    document.querySelector(".dotcanvas-controls>.canvas-box").addEventListener("click", () => {
       plot.setInteraction("box");
     });
 
-    document.querySelector(".dotcanvas>.canvas-pan").addEventListener("click", () => {
+    document.querySelector(".dotcanvas-controls>.canvas-pan").addEventListener("click", () => {
       plot.setInteraction("pan");
     });
 
-    document.querySelector(".dotcanvas>.canvas-lasso").addEventListener("click", () => {
+    document.querySelector(".dotcanvas-controls>.canvas-lasso").addEventListener("click", () => {
       plot.setInteraction("lasso");
     });
 
-    document.querySelector(".dotcanvas>.enable-highlight").addEventListener("click", () => {
+    document.querySelector(".dotcanvas-controls>.enable-highlight").addEventListener("click", () => {
       plot.enableHighlight();
     });
     
-    document.querySelector(".dotcanvas>.disable-highlight").addEventListener("click", () => {
+    document.querySelector(".dotcanvas-controls>.disable-highlight").addEventListener("click", () => {
       plot.disableHighlight();
     });
 
-    document.querySelector(".dotcanvas>.clear-highlight").addEventListener("click", () => {
+    document.querySelector(".dotcanvas-controls>.clear-highlight").addEventListener("click", () => {
       plot.clearHighlight();
     });
 
 
     let plot2 = new RectplotGL(".rectcanvas");
-    plot2.setInput(data);
+
+    plot2.setInput(data, intensityLegendData);
+    plot2.setIntensityLegendOptions("right");
 
     plot2.hoverCallback = function (point) {
       if (point) {
@@ -308,27 +345,27 @@
 
     plot2.render();
 
-    document.querySelector(".rectcanvas>.canvas-box").addEventListener("click", () => {
+    document.querySelector(".rectcanvas-controls>.canvas-box").addEventListener("click", () => {
       plot2.setInteraction("box");
     });
 
-    document.querySelector(".rectcanvas>.canvas-pan").addEventListener("click", () => {
+    document.querySelector(".rectcanvas-controls>.canvas-pan").addEventListener("click", () => {
       plot2.setInteraction("pan");
     });
 
-    document.querySelector(".rectcanvas>.canvas-lasso").addEventListener("click", () => {
+    document.querySelector(".rectcanvas-controls>.canvas-lasso").addEventListener("click", () => {
       plot2.setInteraction("lasso");
     });
 
-    document.querySelector(".rectcanvas>.enable-highlight").addEventListener("click", () => {
+    document.querySelector(".rectcanvas-controls>.enable-highlight").addEventListener("click", () => {
       plot2.enableHighlight();
     });
 
-    document.querySelector(".rectcanvas>.disable-highlight").addEventListener("click", () => {
+    document.querySelector(".rectcanvas-controls>.disable-highlight").addEventListener("click", () => {
       plot2.disableHighlight();
     });
 
-    document.querySelector(".rectcanvas>.clear-highlight").addEventListener("click", () => {
+    document.querySelector(".rectcanvas-controls>.clear-highlight").addEventListener("click", () => {
       plot2.clearHighlight();
     });
 
@@ -350,15 +387,15 @@
 
     plot3.render();
 
-    document.querySelector(".tickcanvas>.canvas-box").addEventListener("click", () => {
+    document.querySelector(".tickcanvas-controls>.canvas-box").addEventListener("click", () => {
       plot3.setInteraction("box");
     });
 
-    document.querySelector(".tickcanvas>.canvas-pan").addEventListener("click", () => {
+    document.querySelector(".tickcanvas-controls>.canvas-pan").addEventListener("click", () => {
       plot3.setInteraction("pan");
     });
 
-    document.querySelector(".tickcanvas>.canvas-lasso").addEventListener("click", () => {
+    document.querySelector(".tickcanvas-controls>.canvas-lasso").addEventListener("click", () => {
       plot3.setInteraction("lasso");
     });
 
@@ -393,27 +430,27 @@
 
     plotgh.render();
 
-    document.querySelector(".ghcanvas>.canvas-box").addEventListener("click", () => {
+    document.querySelector(".ghcanvas-controls>.canvas-box").addEventListener("click", () => {
       plotgh.setInteraction("box");
     });
 
-    document.querySelector(".ghcanvas>.canvas-pan").addEventListener("click", () => {
+    document.querySelector(".ghcanvas-controls>.canvas-pan").addEventListener("click", () => {
       plotgh.setInteraction("pan");
     });
 
-    document.querySelector(".ghcanvas>.canvas-lasso").addEventListener("click", () => {
+    document.querySelector(".ghcanvas-controls>.canvas-lasso").addEventListener("click", () => {
       plotgh.setInteraction("lasso");
     });
 
-    document.querySelector(".ghcanvas>.enable-highlight").addEventListener("click", () => {
+    document.querySelector(".ghcanvas-controls>.enable-highlight").addEventListener("click", () => {
       plotgh.enableHighlight();
     });
 
-    document.querySelector(".ghcanvas>.disable-highlight").addEventListener("click", () => {
+    document.querySelector(".ghcanvas-controls>.disable-highlight").addEventListener("click", () => {
       plotgh.disableHighlight();
     });
 
-    document.querySelector(".ghcanvas>.clear-highlight").addEventListener("click", () => {
+    document.querySelector(".ghcanvas-controls>.clear-highlight").addEventListener("click", () => {
       plotgh.clearHighlight();
     });
 

--- a/app/index.js
+++ b/app/index.js
@@ -2485,7 +2485,8 @@ class SVGInteractor {
    *
    * @param {SVGElement} svg container for all svg elements
    */
-  constructor(svg) {
+  constructor(svg, labelClickHandler) {
+    this.labelClickHandler = labelClickHandler;
     this.svg = svg;
     this.d3SVG = select(this.svg);
     this.svg.style.width = "100%";
@@ -2522,6 +2523,7 @@ class SVGInteractor {
     this.svg.style.width = styles.width;
     this.svg.style.height = styles.height;
     this.svg.style.margin = styles.margin;
+    this.svg.style.cursor = "default"; // or "none"
 
     this.initialX = undefined; // used for updating labels
     this.initialY = undefined;
@@ -2599,21 +2601,61 @@ class SVGInteractor {
       );
     }
 
-    select(this._labelMarker)
+    const labels = select(this._labelMarker)
       .selectAll("text")
-      .data(this.specification.labels)
+      .data(this.specification.labels);
+    labels
+      .enter()
+      .append("text")
+      .merge(labels) // Updates both existing and new nodes
       .text((d) => d.text)
-      .attr("x", (d, i) => {
+      .attr("style", "pointer-events: bounding-box") // Add this line to make the labels respond to pointer events
+      .style("user-select", "none") // add this line
+      .on("click", (event, d) => {
+        const clickedIndex = select(this._labelMarker)
+          .selectAll("text")
+          .nodes()
+          .indexOf(event.currentTarget);
+
+        this.labelClickHandler({
+          label: d.text,
+          index: clickedIndex,
+          labelObject: d,
+        });
+      })
+      .attr("x", (d, i, nodes) => {
+        const svgNode = this.d3SVG.node();
+        const rect = svgNode.getBoundingClientRect();
+        const width = rect.width;
+
         if (d.fixedX) {
           return this.initialX[i];
         }
-        return this._calculateViewportSpotInverse(d.x, d.y)[0];
+
+        const xPos = this._calculateViewportSpotInverse(d.x, d.y)[0];
+
+        if (xPos < 0 || xPos > width) {
+          select(nodes[i]).remove();
+        } else {
+          return xPos;
+        }
       })
-      .attr("y", (d, i) => {
+      .attr("y", (d, i, nodes) => {
+        const svgNode = this.d3SVG.node();
+        const rect = svgNode.getBoundingClientRect();
+        const height = rect.height;
+
         if (d.fixedY) {
           return this.initialY[i];
         }
-        return this._calculateViewportSpotInverse(d.x, d.y)[1];
+
+        const yPos = this._calculateViewportSpotInverse(d.x, d.y)[1];
+
+        if (yPos < 0 || yPos > height) {
+          select(nodes[i]).remove();
+        } else {
+          return yPos;
+        }
       })
       .each(function (d) {
         // Set any possible svg properties specified in label
@@ -2624,6 +2666,9 @@ class SVGInteractor {
           select(this).attr(property, d[property]);
         }
       });
+
+    // Remove any old labels
+    labels.exit().remove();
   }
 
   _calculateAxis(dimension, orientation, specification, genomeScale, anchor) {
@@ -2828,7 +2873,8 @@ class MouseReader {
 
     // Initializing elements to show user their current selection
     this.SVGInteractor = new SVGInteractor(
-      document.createElementNS("http://www.w3.org/2000/svg", "svg")
+      document.createElementNS("http://www.w3.org/2000/svg", "svg"),
+      handler.dispatchEvent.bind(handler, "labelClicked")
     );
   }
 
@@ -7013,10 +7059,46 @@ v.addSchema(track, "/track");
  * @returns boolean
  */
 const isJSONValid = (json) => {
-  const validation = v.validate(json, visualization);
+  let jsonToValidate = json;
+
+  // Check if any typed arrays are in 'defaultData'
+  const typedArrayTypes = [
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+    BigInt64Array,
+    BigUint64Array,
+  ];
+
+  if (
+    json.defaultData &&
+    Object.values(json.defaultData).some((value) =>
+      typedArrayTypes.some((T) => value instanceof T)
+    )
+  ) {
+    // Create a deep copy of the json if a typed array needs to be converted
+    jsonToValidate = JSON.parse(JSON.stringify(json));
+
+    // Convert typed arrays to standard arrays
+    Object.keys(jsonToValidate.defaultData).forEach((key) => {
+      if (typedArrayTypes.some((T) => json.defaultData[key] instanceof T)) {
+        jsonToValidate.defaultData[key] = Array.from(json.defaultData[key]);
+      }
+    });
+  }
+
+  const validation = v.validate(jsonToValidate, visualization);
+
   if (!validation.valid) {
     console.error(validation.errors);
   }
+
   return validation.valid;
 };
 
@@ -7119,25 +7201,18 @@ class WebGLVis {
         if (message.data.closestPoint === undefined) {
           return;
         }
-        this.parent.dispatchEvent(
-          new CustomEvent("pointHovered", { detail: message })
-        );
+        this.dispatchEvent("pointHovered", message);
       } else if (message.data.type === "getClickPoint") {
         if (message.data.closestPoint === undefined) {
           return;
         }
-        this.parent.dispatchEvent(
-          new CustomEvent("pointClicked", { detail: message })
-        );
+        this.dispatchEvent("pointClicked", message);
       } else if (
         message.data.type === "selectBox" ||
         message.data.type === "selectLasso"
       ) {
-        this.parent.dispatchEvent(
-          new CustomEvent("onSelectionEnd", { detail: message })
-        );
+        this.dispatchEvent("onSelectionEnd", message);
         this.dataWorkerStream.push(message);
-        console.log(this.dataWorkerStream);
       }
     };
     this.dataWorker.onerror = (e) => {
@@ -7302,6 +7377,8 @@ class WebGLVis {
    * "onSelection": fires while user is changing the selection box/lasso
    * "onSelectionEnd": fires when a selection has been completed and the results are in the dataWorkerStream
    * "pointHovered": fires when pointer hovers over a datapoint
+   * "pointClicked": fires when pointer clicks on a datapoint
+   * "labelClicked": fires when pointer clicks on a label
    *
    * For information on the parameters and functionality see:
    *   https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
@@ -7312,6 +7389,21 @@ class WebGLVis {
    */
   addEventListener(type, listener, options) {
     this.parent.addEventListener(type, listener, options);
+  }
+
+  /**
+   * Dispatches an event on the visualization on the appropriate component.
+   * @param {String} eventName
+   * event name can be one of the following:
+   * "pointHovered" - fires when pointer hovers over a datapoint
+   * "pointClicked" - fires when pointer clicks on a datapoint
+   * "labelClicked" - fires when pointer clicks on a label
+   * "onSelectionEnd" - fires when a selection has been completed and the results are in the dataWorkerStream
+   * @param {Object} message
+   **/
+  dispatchEvent(eventName, message) {
+    const event = new CustomEvent(eventName, { detail: message });
+    this.parent.dispatchEvent(event);
   }
 
   /**
@@ -7340,76 +7432,27 @@ const getMinMax = (arr) => {
   return [min, max];
 };
 
-/**
- * Function to convert a hexadecimal color to its RGB equivalent.
- *
- * @param {string} hex - The hexadecimal color string. Must start with "#" and be followed by 6 hexadecimal digits.
- * @returns {Array<number>} An array containing the RGB values (0-255) in the order [r, g, b].
- */
-function hexToRGB(hex) {
-  let r = parseInt(hex.slice(1, 3), 16),
-    g = parseInt(hex.slice(3, 5), 16),
-    b = parseInt(hex.slice(5, 7), 16);
-  return [r, g, b];
-}
+const parseMargins = (margins) => {
+  const parsedMargins = {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  };
 
-/**
- * Function to convert an RGB color to its hexadecimal equivalent.
- *
- * @param {Array<number>} rgb - An array of three numbers [r, g, b] representing an RGB color.
- * @returns {string} A string representing the color in hexadecimal format.
- */
-function rgbToHex(rgb) {
-  let r = rgb[0].toString(16),
-    g = rgb[1].toString(16),
-    b = rgb[2].toString(16);
-  return (
-    "#" +
-    ((r.length == 1 ? "0" : "") + r) +
-    ((g.length == 1 ? "0" : "") + g) +
-    ((b.length == 1 ? "0" : "") + b)
-  );
-}
+  for (let key in margins) {
+    if (margins.hasOwnProperty(key)) {
+      const value = margins[key];
+      const parsedValue = parseInt(value, 10);
 
-/**
- * Function to mix a color with white to create a "brightened" effect.
- *
- * @param {Array<number>} rgb - An array of three numbers [r, g, b] representing an RGB color.
- * @param {number} amount - The brightening factor. A value between 0 (no change) and 1 (complete white).
- * @returns {Array<number>} An array containing the RGB values of the brightened color.
- */
-function mixWithWhite(rgb, amount) {
-  return [
-    Math.floor(rgb[0] + (255 - rgb[0]) * amount),
-    Math.floor(rgb[1] + (255 - rgb[1]) * amount),
-    Math.floor(rgb[2] + (255 - rgb[2]) * amount),
-  ];
-}
-
-/**
- * Function to convert a color from the "rgb(r, g, b)" string format to an array of numbers.
- *
- * @param {string} rgbStr - The color in "rgb(r, g, b)" string format.
- * @returns {Array<number>} An array containing the RGB values (0-255) in the order [r, g, b].
- */
-function strToRGB(rgbStr) {
-  let match = rgbStr.match(/rgb\((\d+), (\d+), (\d+)\)/);
-  if (match) {
-    return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])];
-  } else {
-    throw new Error("Invalid RGB string format");
+      if (!isNaN(parsedValue)) {
+        parsedMargins[key] = parsedValue;
+      }
+    }
   }
-}
 
-/**
- * Function to determine whether a given color is in RGB format.
- *
- * @param {Array<number> | string} color - The color in either RGB format (as a string in the "rgb(r, g, b)" format) or hexadecimal format (as a string).
- * @returns {boolean} True if the color is in RGB format, false otherwise.
- */
-function isRGB(color) {
-  return color.startsWith("rgb");
-}
+  return parsedMargins;
+};
 
 /**
  * Base class for all matrix like layout plots.
@@ -7428,6 +7471,8 @@ class BaseGL {
    */
   constructor(selectorOrElement) {
     this.elem = selectorOrElement;
+    // Default legend position
+    this.legendPosition = "bottom";
     if (
       typeof selectorOrElement === "string" ||
       selectorOrElement instanceof String
@@ -7472,13 +7517,14 @@ class BaseGL {
         sdata &&
         sdata.selection.indices.length > 0
       ) {
-        this.highlightIndices(sdata.selection.indices, true);
+        this.highlightIndices(sdata.selection.indices, null, true);
       }
 
       self.selectionCallback(e.detail.data);
     });
 
     this.highlightedIndices = [];
+    this.indexStates = {};
   }
 
   /**
@@ -7546,9 +7592,13 @@ class BaseGL {
    * @param {Array} data.y, y coordinates
    * @param {Array} data.xlabels, labels along the x-axis
    * @param {Array} data.ylabels, labels along the y-axis
+   * @param {Array} legendData, data for the legend
+   * @param {Array} legendData.labels, labels for the legend
+   * @param {Array} legendData.colors, colors for the legend
+   * @param {Array} legendData.intensity, intensity for the color inside legend
    * @memberof BaseGL
    */
-  setInput(data) {
+  setInput(data, legendData = null) {
     if (
       isObject(data) &&
       "x" in data &&
@@ -7610,6 +7660,8 @@ class BaseGL {
     } else {
       throw `input data must contain x and y attributes`;
     }
+
+    this.legendData = legendData;
   }
 
   /**
@@ -7672,6 +7724,22 @@ class BaseGL {
   }
 
   /**
+   * Set the legend options for the visualization.
+   * @param {string} legentPosition, position of the legend, can be `top`, `bottom`, `left` or `right`
+   * @param {DOMElement} legendDomElement, the DOM element to use for the legend
+   **/
+  setIntensityLegendOptions(legentPosition, legendDomElement, width, height) {
+    this.isLegendDomElementProvided = !!legendDomElement;
+    this.legendPosition = legentPosition;
+    this.legendWidth = width;
+    this.legendHeight = height;
+
+    if (!legendDomElement) {
+      this.legendDomElement = this.elem.lastChild;
+    } else this.legendDomElement = legendDomElement;
+  }
+
+  /**
    * resize the plot, without having to send the data to the GPU.
    *
    * @param {number} width
@@ -7728,6 +7796,10 @@ class BaseGL {
     if (height) {
       this._spec.height = height;
     }
+    // Render the legend
+    if (this.legendData && this.legendDomElement) {
+      this.renderLegend();
+    }
 
     if (this._renderCount == 0) {
       this.plot.setSpecification(this._spec);
@@ -7760,32 +7832,224 @@ class BaseGL {
       }
 
       if (this.highlightEnabled && hdata && hdata.indices.length > 0) {
-        this.highlightIndices(hdata.indices);
+        const index = hdata.indices[0];
+        const shouldHighlight = !this.indexStates[index]; // reverse the current state
+        this.indexStates[index] = shouldHighlight;
+        this.highlightIndices([index], shouldHighlight);
       }
 
       self.clickCallback(hdata);
     });
+
+    this.plot.addEventListener("labelClicked", (e) => {
+      e.preventDefault();
+      if (this.highlightEnabled && e && e.detail && e.detail.labelObject) {
+        const type = e.detail.labelObject.type;
+        const index = e.detail.labelObject.index;
+        const indices = [];
+        if (type === "column") {
+          for (let i = index; i < this.ncols * this.nrows; i += this.nrows) {
+            indices.push(i);
+          }
+        } else if (type === "row") {
+          for (let i = index * this.nrows; i < (index + 1) * this.nrows; i++) {
+            indices.push(i);
+          }
+        }
+
+        // Decide whether to highlight or unhighlight
+        const shouldHighlight = indices.some(
+          (index) => !this.indexStates[index]
+        );
+        indices.forEach((index) => (this.indexStates[index] = shouldHighlight));
+
+        this.highlightIndices(indices, shouldHighlight);
+      }
+    });
   }
 
-  highlightIndices(indices, forceSet = false) {
+  /**
+   * Render the legend for the intensity plot.
+   * This is used to render the legend for the intensity plot.
+   **/
+  renderLegend() {
+    const position = this.legendPosition;
+    // Only render the legend if we have the legend data and the legend dom element
+    if (!this.legendDomElement || !this.legendData) return;
+
+    const parsedMargins = parseMargins(this._spec.margins);
+    const containerWidth =
+      this.legendWidth ||
+      this.elem.clientWidth - parsedMargins.left - parsedMargins.right;
+    const containerHeight =
+      this.legendHeight ||
+      this.elem.clientHeight - parsedMargins.top - parsedMargins.bottom;
+
+    const averageCharWidth = 6; // rough estimation of the width of a single character
+    const legendWidth = containerWidth - 2 * averageCharWidth;
+    const legendHeight = containerHeight - 2 * averageCharWidth;
+    const legendSize = 20;
+    const labelSize = 25;
+
+    // Adjust the SVG size and the legend position according to the position parameter
+    let svgWidth, svgHeight, transformX, transformY;
+    if (position === "left" || position === "right") {
+      svgWidth = legendSize + labelSize;
+      svgHeight = containerHeight;
+      transformY = averageCharWidth;
+    } else {
+      svgWidth = containerWidth;
+      svgHeight = legendSize + labelSize;
+      transformX = averageCharWidth;
+    }
+
+    const svgContainer = d3
+      .select(this.legendDomElement)
+      .append("svg")
+      .attr("width", svgWidth)
+      .attr("height", svgHeight)
+      .attr("overflow", "visible");
+
+    const defs = svgContainer.append("defs");
+
+    const gradientId = `linear-gradient-${(Math.random() * 1000).toFixed()}`;
+
+    const gradient = defs
+      .append("linearGradient")
+      .attr("id", gradientId)
+      .attr("x1", "0%")
+      .attr("y1", "0%")
+      .attr("x2", position === "left" || position === "right" ? "0%" : "100%")
+      .attr("y2", position === "left" || position === "right" ? "100%" : "0%");
+
+    gradient
+      .selectAll("stop")
+      .data(this.legendData)
+      .enter()
+      .append("stop")
+      .attr("offset", (d) => d.intensity * 100 + "%")
+      .attr("stop-color", (d) => d.color);
+
+    // Create a mapping from intensity to label
+    const intensityToLabel = {};
+    this.legendData.forEach((d) => {
+      if (d.label !== "") {
+        intensityToLabel[d.intensity] = d.label;
+      }
+    });
+
+    const intensityScale = d3
+      .scaleLinear()
+      .range([
+        0,
+        position === "left" || position === "right"
+          ? legendHeight
+          : legendWidth,
+      ])
+      .domain([0, 1]);
+
+    let legendAxis;
+    if (position === "left") {
+      legendAxis = d3.axisLeft(intensityScale);
+      transformX = labelSize;
+    } else if (position === "top") {
+      legendAxis = d3.axisTop(intensityScale);
+      transformY = labelSize;
+    } else if (position === "right") {
+      transformX = legendSize;
+      legendAxis = d3.axisRight(intensityScale);
+    } else {
+      transformY = legendSize;
+      legendAxis = d3.axisBottom(intensityScale);
+    }
+
+    legendAxis
+      .tickValues(Object.keys(intensityToLabel).map(Number)) // Only use intensities that have labels
+      .tickFormat((d) => intensityToLabel[d]); // Use the intensity to label mapping
+
+    svgContainer
+      .append("g")
+      .attr("transform", `translate(${transformX}, ${transformY})`)
+      .call(legendAxis);
+
+    const maxLabelChars = Math.max(
+      ...this.legendData.map((d) => d.label.toString().length)
+    ); // length of the longest label
+
+    let rectX, rectY;
+    if (position === "top") {
+      rectX = averageCharWidth;
+      rectY = maxLabelChars * averageCharWidth + 8; // Offset to move gradient down
+    } else if (position === "left") {
+      rectX = maxLabelChars * averageCharWidth + 8; // Offset to move gradient right
+      rectY = averageCharWidth;
+    } else if (position === "right") {
+      rectY = averageCharWidth;
+      rectX = 0;
+    } else if (position === "bottom") {
+      rectX = averageCharWidth;
+      rectY = 0;
+    }
+
+    svgContainer
+      .append("rect")
+      .attr(
+        "width",
+        position === "left" || position === "right" ? legendSize : legendWidth
+      )
+      .attr(
+        "height",
+        position === "left" || position === "right" ? legendHeight : legendSize
+      )
+      .style("fill", `url(#${gradientId})`)
+      .attr("x", rectX)
+      .attr("y", rectY);
+
+    // Update margins to account for the legend only if dom element is not provided
+    if (!this.isLegendDomElementProvided) {
+      this._spec.margins = {
+        ...this._spec.margins,
+        [position]: `calc(${
+          (position === "left" || position === "right" ? 45 : 45) + "px"
+        } + ${this._spec.margins[position]})`,
+      };
+
+      // set svg container to position absolute and position value to 0
+      svgContainer.style("position", "absolute").style(position, "0px");
+
+      if (position === "right" || position === "left") {
+        svgContainer.style("margin-top", parsedMargins.top);
+      } else if (position === "top" || position === "bottom") {
+        svgContainer.style("margin-left", parsedMargins.left);
+      }
+    }
+  }
+
+  /**
+   * Highlight the indices on the plot.
+   * @memberof BaseGL
+   * @param {Array} indices, indices to be highlighted.
+   * @param {boolean} forceSet, if true, set the indices to be highlighted, else toggle the indices.
+   * @example
+   * // Highlight indices
+   * plot.highlightIndices([1, 2, 3]);
+   **/
+  highlightIndices(indices, shouldHighlight, forceSet = false) {
     if (forceSet) {
       this.highlightedIndices = [...indices];
-    } else if (this.highlightedIndices.length > 0) {
+      indices.forEach((index) => (this.indexStates[index] = true));
+    } else {
       indices.forEach((index) => {
         const foundIndex = this.highlightedIndices.indexOf(index);
-        if (foundIndex > -1) {
-          this.highlightedIndices = this.highlightedIndices.filter(
-            (item) => item !== index
-          );
-        } else {
+        if (!shouldHighlight && foundIndex > -1) {
+          this.highlightedIndices.splice(foundIndex, 1);
+        } else if (shouldHighlight && foundIndex === -1) {
           this.highlightedIndices.push(index);
         }
       });
-    } else {
-      this.highlightedIndices.push(...indices);
     }
     this.highlightedIndicesCallback(this.highlightedIndices);
-    this.reRender();
+    this.reRenderOnHighlight();
   }
 
   /**
@@ -7822,33 +8086,38 @@ class BaseGL {
    **/
   clearHighlight() {
     this.highlightedIndices = [];
+    this.indexStates = {};
     this.highlightedIndicesCallback(this.highlightedIndices);
-    this.reRender();
+    this.reRenderOnHighlight();
   }
 
   /**
-   * Re-render the plot. This is useful when the data is updated.
+   * Re-render the plot. This is useful when the highlight data is updated.
    * @memberof BaseGL
    */
-  reRender() {
-    this.plot.updateSpecification({
-      ...this._spec,
-      defaultData: {
-        ...this._spec.defaultData,
-        color: this._spec.defaultData.color.map((color, index) => {
-          if (
-            this.highlightedIndices.length === 0 ||
-            this.highlightedIndices.includes(index)
-          ) {
-            return color;
-          } else {
-            const rgb = isRGB(color) ? strToRGB(color) : hexToRGB(color);
-            const dimmedRgb = mixWithWhite(rgb, 0.7); // 0.7 is the dimming factor
-            return rgbToHex(dimmedRgb);
-          }
-        }),
-      },
-    });
+  reRenderOnHighlight() {
+    const opacityData = this.createOpacityArray(
+      this._spec.defaultData.color.length,
+      this.highlightedIndices
+    );
+    this._generateSpecForEncoding(this._spec, "opacity", opacityData);
+    this.plot.updateSpecification(this._spec);
+  }
+
+  /**
+   * Create an array of length `length` with the specified indexes set to 1
+   * @memberof BaseGL
+   * @param {number} length, length of the array
+   * @param {Array} indexes, indexes to be set to 1
+   * @return {Array} an array of length `length` with the specified indexes set to 1
+   **/
+  createOpacityArray(length, indexes) {
+    // Create an array of length `length` with all values set to 0.4 if indexes are specified else 1
+    const arr = new Array(length).fill(indexes.length ? 0.4 : 1);
+    for (let i of indexes) {
+      arr[i] = 1; // Set the specified indexes to 1
+    }
+    return arr;
   }
 
   /**
@@ -7861,7 +8130,7 @@ class BaseGL {
    */
   clearHighlightedIndices() {
     this.highlightedIndices = [];
-    this.reRender();
+    this.reRenderOnHighlight();
   }
 
   /**
@@ -7955,6 +8224,8 @@ class DotplotGL extends BaseGL {
         labels.push({
           x: -1.05 + (2 * ilx + 1) / xlabels_len,
           y: 1.05,
+          type: "row",
+          index: ilx,
           text: this.input["xlabels"][ilx],
           fixedY: true,
           "text-anchor": "center",
@@ -7972,6 +8243,8 @@ class DotplotGL extends BaseGL {
         labels.push({
           x: -1.05,
           y: -1.05 + (2 * ily + 1) / ylabels_len,
+          type: "column",
+          index: ily,
           text: this.input["ylabels"][ily],
           fixedX: true,
           "text-anchor": "end",
@@ -8039,7 +8312,6 @@ class DotplotGL extends BaseGL {
  * @extends {BaseGL}
  */
 class RectplotGL extends BaseGL {
-
   /**
    * Creates an instance of RectplotGL.
    * @param {string} selectorOrElement, a html dom selector or element.
@@ -8062,7 +8334,7 @@ class RectplotGL extends BaseGL {
    * Generate the specification for Rect heatmap Plots.
    * checkout epiviz.gl for more information.
    *
-   * @return {object} a specification object that epiviz.gl can understand 
+   * @return {object} a specification object that epiviz.gl can understand
    * @memberof RectplotGL
    */
   generateSpec() {
@@ -8104,6 +8376,8 @@ class RectplotGL extends BaseGL {
         labels.push({
           x: -1.05 + (2 * ilx + 1) / xlabels_len,
           y: 1.05,
+          type: "row",
+          index: ilx,
           text: this.input["xlabels"][ilx],
           fixedY: true,
           "text-anchor": "center",
@@ -8121,6 +8395,8 @@ class RectplotGL extends BaseGL {
         labels.push({
           x: -1.05,
           y: -1.05 + (2 * ily + 1) / ylabels_len,
+          type: "column",
+          index: ily,
           text: this.input["ylabels"][ily],
           fixedX: true,
           "text-anchor": "end",
@@ -8185,8 +8461,6 @@ class RectplotGL extends BaseGL {
  * @extends {BaseGL}
  */
 class TickplotGL extends BaseGL {
-
-
   /**
    * Creates an instance of TickplotGL.
    * @param {string} selectorOrElement, a html dom selector or element.
@@ -8205,12 +8479,11 @@ class TickplotGL extends BaseGL {
     };
   }
 
-
   /**
    * Generate the specification for Tick Plots.
    * checkout epiviz.gl for more information.
    *
-   * @return {object} a specification object that epiviz.gl can understand 
+   * @return {object} a specification object that epiviz.gl can understand
    * @memberof TickplotGL
    */
   generateSpec() {
@@ -8227,6 +8500,8 @@ class TickplotGL extends BaseGL {
         labels.push({
           x: -1 + (2 * ilx + 1) / xlabels_len,
           y: 1.05,
+          type: "row",
+          index: ilx,
           text: this.input["xlabels"][ilx],
           fixedY: true,
           "text-anchor": "center",
@@ -8244,6 +8519,8 @@ class TickplotGL extends BaseGL {
         labels.push({
           x: -1.1,
           y: -1 + (2 * ily + 1) / ylabels_len,
+          type: "column",
+          index: ily,
           text: this.input["ylabels"][ily],
           fixedX: true,
           "text-anchor": "end",

--- a/app/index.js
+++ b/app/index.js
@@ -7592,13 +7592,9 @@ class BaseGL {
    * @param {Array} data.y, y coordinates
    * @param {Array} data.xlabels, labels along the x-axis
    * @param {Array} data.ylabels, labels along the y-axis
-   * @param {Array} legendData, data for the legend
-   * @param {Array} legendData.labels, labels for the legend
-   * @param {Array} legendData.colors, colors for the legend
-   * @param {Array} legendData.intensity, intensity for the color inside legend
    * @memberof BaseGL
    */
-  setInput(data, legendData = null) {
+  setInput(data) {
     if (
       isObject(data) &&
       "x" in data &&
@@ -7660,8 +7656,6 @@ class BaseGL {
     } else {
       throw `input data must contain x and y attributes`;
     }
-
-    this.legendData = legendData;
   }
 
   /**
@@ -7673,6 +7667,8 @@ class BaseGL {
    * @param {Array|number} encoding.opacity, same as size, but sets the opacity for each cell.
    * @param {Array|number} encoding.xgap, same as size, but sets the gap along x-axis.
    * @param {Array|number} encoding.ygap, same as size, but sets the gap along y-axis.
+   * @param {Array} encoding.legendIntensityData, an array of objects containing color, intensity, and label for the legend.
+   * e.g  [{color: "#000000", intensity: 1, label: "0.1"}]
    * @memberof BaseGL
    */
   setState(encoding) {
@@ -7702,6 +7698,10 @@ class BaseGL {
 
     if ("ygap" in encoding) {
       this.state["ygap"] = encoding["ygap"];
+    }
+
+    if ("intensityLegendData" in encoding) {
+      this.intensityLegendData = encoding["intensityLegendData"];
     }
   }
 
@@ -7797,7 +7797,7 @@ class BaseGL {
       this._spec.height = height;
     }
     // Render the legend
-    if (this.legendData && this.legendDomElement) {
+    if (this.intensityLegendData && this.legendDomElement) {
       this.renderLegend();
     }
 
@@ -7875,7 +7875,7 @@ class BaseGL {
   renderLegend() {
     const position = this.legendPosition;
     // Only render the legend if we have the legend data and the legend dom element
-    if (!this.legendDomElement || !this.legendData) return;
+    if (!this.legendDomElement || !this.intensityLegendData) return;
 
     const parsedMargins = parseMargins(this._spec.margins);
     const containerWidth =
@@ -7924,7 +7924,7 @@ class BaseGL {
 
     gradient
       .selectAll("stop")
-      .data(this.legendData)
+      .data(this.intensityLegendData)
       .enter()
       .append("stop")
       .attr("offset", (d) => d.intensity * 100 + "%")
@@ -7932,7 +7932,7 @@ class BaseGL {
 
     // Create a mapping from intensity to label
     const intensityToLabel = {};
-    this.legendData.forEach((d) => {
+    this.intensityLegendData.forEach((d) => {
       if (d.label !== "") {
         intensityToLabel[d.intensity] = d.label;
       }
@@ -7973,7 +7973,7 @@ class BaseGL {
       .call(legendAxis);
 
     const maxLabelChars = Math.max(
-      ...this.legendData.map((d) => d.label.toString().length)
+      ...this.intensityLegendData.map((d) => d.label.toString().length)
     ); // length of the longest label
 
     let rectX, rectY;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epiviz.heatmap.gl",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": "https://github.com/jkanche/epiviz.heatmap.gl",
   "homepage": "https://github.com/jkanche/epiviz.heatmap.gl",
   "author": {

--- a/src/BaseGL.js
+++ b/src/BaseGL.js
@@ -284,9 +284,11 @@ class BaseGL {
    * @param {string} legentPosition, position of the legend, can be `top`, `bottom`, `left` or `right`
    * @param {DOMElement} legendDomElement, the DOM element to use for the legend
    **/
-  setIntensityLegendOptions(legentPosition, legendDomElement) {
+  setIntensityLegendOptions(legentPosition, legendDomElement, width, height) {
     this.isLegendDomElementProvided = !!legendDomElement;
     this.legendPosition = legentPosition;
+    this.legendWidth = width;
+    this.legendHeight = height;
 
     if (!legendDomElement) {
       this.legendDomElement = this.elem.lastChild;
@@ -433,8 +435,10 @@ class BaseGL {
 
     const parsedMargins = parseMargins(this._spec.margins);
     const containerWidth =
+      this.legendWidth ||
       this.elem.clientWidth - parsedMargins.left - parsedMargins.right;
     const containerHeight =
+      this.legendHeight ||
       this.elem.clientHeight - parsedMargins.top - parsedMargins.bottom;
 
     const averageCharWidth = 6; // rough estimation of the width of a single character
@@ -461,12 +465,6 @@ class BaseGL {
       .attr("width", svgWidth)
       .attr("height", svgHeight)
       .attr("overflow", "visible");
-
-    if (position === "right" || position === "left") {
-      svgContainer.style("margin-top", parsedMargins.top);
-    } else if (position === "top" || position === "bottom") {
-      svgContainer.style("margin-left", parsedMargins.left);
-    }
 
     const defs = svgContainer.append("defs");
 
@@ -574,6 +572,12 @@ class BaseGL {
 
       // set svg container to position absolute and position value to 0
       svgContainer.style("position", "absolute").style(position, "0px");
+
+      if (position === "right" || position === "left") {
+        svgContainer.style("margin-top", parsedMargins.top);
+      } else if (position === "top" || position === "bottom") {
+        svgContainer.style("margin-left", parsedMargins.left);
+      }
     }
   }
 

--- a/src/BaseGL.js
+++ b/src/BaseGL.js
@@ -148,6 +148,10 @@ class BaseGL {
    * @param {Array} data.y, y coordinates
    * @param {Array} data.xlabels, labels along the x-axis
    * @param {Array} data.ylabels, labels along the y-axis
+   * @param {Array} legendData, data for the legend
+   * @param {Array} legendData.labels, labels for the legend
+   * @param {Array} legendData.colors, colors for the legend
+   * @param {Array} legendData.intensity, intensity for the color inside legend
    * @memberof BaseGL
    */
   setInput(data, legendData = null) {
@@ -276,18 +280,9 @@ class BaseGL {
   }
 
   /**
-   * Set the legend data for the intensity plot.
-   * This is used to render the legend for the intensity plot.
-   * The legend is rendered as a separate canvas element.
-   * The legend data is an array of objects, each object has the following attributes
-   * color - the color to render
-   * label - the label to render
-   * intensity - the value to render
-   *  @example
-   * [
-   * {color: "#000000", label: "label1", intensity: 0.1},
-   * {color: "#000000", label: "label2", intensity: 0.2},
-   * {color: "#000000", label: "label3", intensity: 0.3},
+   * Set the legend options for the visualization.
+   * @param {string} legentPosition, position of the legend, can be `top`, `bottom`, `left` or `right`
+   * @param {DOMElement} legendDomElement, the DOM element to use for the legend
    **/
   setIntensityLegendOptions(legentPosition, legendDomElement) {
     this.isLegendDomElementProvided = !!legendDomElement;

--- a/src/BaseGL.js
+++ b/src/BaseGL.js
@@ -7,6 +7,7 @@ import {
   mixWithWhite,
   isRGB,
   strToRGB,
+  parseMargins,
 } from "./utils";
 
 /**
@@ -435,9 +436,15 @@ class BaseGL {
     // Only render the legend if we have the legend data and the legend dom element
     if (!this.legendDomElement || !this.legendData) return;
 
+    const parsedMargins = parseMargins(this._spec.margins);
+    const containerWidth =
+      this.elem.clientWidth - parsedMargins.left - parsedMargins.right;
+    const containerHeight =
+      this.elem.clientHeight - parsedMargins.top - parsedMargins.bottom;
+
     const averageCharWidth = 6; // rough estimation of the width of a single character
-    const legendWidth = this.elem.clientWidth - 2 * averageCharWidth;
-    const legendHeight = this.elem.clientHeight - 2 * averageCharWidth;
+    const legendWidth = containerWidth - 2 * averageCharWidth;
+    const legendHeight = containerHeight - 2 * averageCharWidth;
     const legendSize = 20;
     const labelSize = 25;
 
@@ -445,10 +452,10 @@ class BaseGL {
     let svgWidth, svgHeight, transformX, transformY;
     if (position === "left" || position === "right") {
       svgWidth = legendSize + labelSize;
-      svgHeight = this.elem.clientHeight;
+      svgHeight = containerHeight;
       transformY = averageCharWidth;
     } else {
-      svgWidth = this.elem.clientWidth;
+      svgWidth = containerWidth;
       svgHeight = legendSize + labelSize;
       transformX = averageCharWidth;
     }
@@ -459,6 +466,12 @@ class BaseGL {
       .attr("width", svgWidth)
       .attr("height", svgHeight)
       .attr("overflow", "visible");
+
+    if (position === "right" || position === "left") {
+      svgContainer.style("margin-top", parsedMargins.top);
+    } else if (position === "top" || position === "bottom") {
+      svgContainer.style("margin-left", parsedMargins.left);
+    }
 
     const defs = svgContainer.append("defs");
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,3 +15,25 @@ export const getMinMax = (arr) => {
   });
   return [min, max];
 };
+
+export const parseMargins = (margins) => {
+  const parsedMargins = {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  };
+
+  for (let key in margins) {
+    if (margins.hasOwnProperty(key)) {
+      const value = margins[key];
+      const parsedValue = parseInt(value, 10);
+
+      if (!isNaN(parsedValue)) {
+        parsedMargins[key] = parsedValue;
+      }
+    }
+  }
+
+  return parsedMargins;
+};


### PR DESCRIPTION
**Example 1, Custom Dom Element Outside Of Graph HTML Node**
<img width="416" alt="image" src="https://github.com/epiviz/epiviz.heatmap.gl/assets/32899991/6a108055-f370-4cd4-8d23-0014f61432ba">
**Example 2 Inside Graph Dom Node**
<img width="417" alt="image" src="https://github.com/epiviz/epiviz.heatmap.gl/assets/32899991/e7e23dc1-6355-4a76-b41d-d843c660cdb4">
Adding Intensity legend is optional. If you want to add it, the simplest way is to provide the data. The data should be in this format.
`[
{
  color: '#fff',
  intensity: 0.1,
  label: '-2'
}
  ]`.

You can use existing setInput method to set the legendData along with heatmap data. like `this.plot.setInput(data, intensityLegendData);` With this option, by default intensity legend will render at bottom of the graph.

You can always change the position using `setIntensityLegendOptions("top" | "bottom" | "left" | "right");`.

If you want the legend to be rendered somewhere else in the dom. You have to provide the selector or dom element along with the position / type of intensity legend you want.
e.g
`setIntensityLegendOptions("top", ".intensity-legend")`


You can also specify width and height.
`setIntensityLegendOptions("top", ".intensity-legend", 400, 500)`


