### PR TITLE
D3 dependency updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epiviz.heatmap.gl",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "repository": "https://github.com/jkanche/epiviz.heatmap.gl",
   "homepage": "https://github.com/jkanche/epiviz.heatmap.gl",
   "author": {

--- a/src/BaseGL.js
+++ b/src/BaseGL.js
@@ -727,8 +727,7 @@ class BaseGL {
       transformX = averageCharWidth;
     }
 
-    const svgContainer = d3
-      .select(this.legendDomElement)
+    const svgContainer = select(this.legendDomElement)
       .append("svg")
       .attr("width", svgWidth)
       .attr("height", svgHeight)


### PR DESCRIPTION
There was a mistake, d3 was being loaded from global d3 object that isn't accessible within the library unless the application using this library has that support.

Updated that now.